### PR TITLE
Global Rate Limit 

### DIFF
--- a/docs/docs/development/node.md
+++ b/docs/docs/development/node.md
@@ -114,6 +114,32 @@ module.exports = {
 }
 ```
 
+
+
+
+#### Global Rate Limit Counter 
+
+You can set limit accesses for all each contracts. 
+
+To use this setting, specify `ratelimit` option in `weavedb.config.js`.
+
+You need to setup redis setting as well. 
+
+The below setting enables you to limit 300 accesses in 5 min. 
+
+
+```js
+module.exports = {
+  ratelimit: {
+    every: 5,
+    limit: 300
+  },
+   redis: {
+    url: "redis://localhost:6379"
+  },
+}
+```
+
 ### Run docker-compose
 
 ```bash

--- a/grpc-node/node-server/rate_limit_counter.js
+++ b/grpc-node/node-server/rate_limit_counter.js
@@ -1,0 +1,156 @@
+const { createClient } = require("redis")
+const { isNil } = require("ramda")
+
+/**
+ * if (!isNil(config.redis) && !isNil(config.ratelimit) && !isNil(config.ratelimit.every)) {
+ * const ratelimit = new RateLimitCount(config.ratelimit, config.redis)
+ *  await ratelimit.init()
+ *  if (checkCountLimit(contractTxId)) {
+ *   return res(`ratelimit ${config.count}`)
+ *  }
+ * }
+ */
+
+class RateLimitCounter {
+  constructor(rateLimitSetting, redisSetting) {
+    try {
+      this.every = rateLimitSetting.every
+      this.limit = rateLimitSetting.limit
+    } catch (e) {
+      this.every = 5 // 5 min
+      this.limit = 10 //
+    }
+    // console.log(`this.every: ${this.every}....rateLimitSetting: ${rateLimitSetting}`)
+    this.prefix = "prefix."
+    try {
+      this.redisClient = createClient(redisSetting)
+      return
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  async init() {
+    if (!isNil(this.redisClient)) {
+      try {
+        await this.redisClient.connect()
+        console.log("redis is ready!")
+        this.redisEnabled = true
+      } catch (e) {
+        // console.log(e)
+        console.log("redis error")
+      }
+    }
+  }
+
+  async checkCountLimit(contractTxId) {
+    if (
+      isNil(this.redisEnabled) ||
+      !this.redisEnabled ||
+      !this.redisClient ||
+      !contractTxId ||
+      contractTxId == ""
+    )
+      return false
+    const cnt = await this.getCount(contractTxId)
+    console.log(
+      `contractTxId: ${contractTxId}, cnt:${cnt}, this.limit: ${this.limit}`
+    )
+    if (cnt > this.limit) {
+      return true
+    }
+    try {
+      await this.countUp(contractTxId)
+    } catch (e) {
+      console.log(e)
+    }
+    return false
+  }
+
+  _getKey(contractTxId, currentTime = 0) {
+    if (
+      isNil(this.redisEnabled) ||
+      !this.redisEnabled ||
+      !this.redisClient ||
+      !contractTxId ||
+      contractTxId == ""
+    )
+      return false
+    if (currentTime <= 0) {
+      currentTime = Date.now()
+    }
+
+    const d = new Date(currentTime)
+    const theorder = Math.floor(d.getUTCMinutes() / this.every)
+    const k = `${
+      this.prefix
+    }.${contractTxId}.${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}-${d.getUTCHours()}-${theorder} `
+    return k
+  }
+
+  async countUp(contractTxId) {
+    if (
+      isNil(this.redisEnabled) ||
+      !this.redisEnabled ||
+      !this.redisClient ||
+      contractTxId == ""
+    )
+      return false
+
+    const k = this._getKey(contractTxId)
+    // console.log("k=",k)
+    if (k) {
+      try {
+        console.log("a")
+        await this.redisClient.incr(k)
+      } catch (e) {
+        console.log(e)
+        return "redis incr err"
+      }
+      return true
+    }
+
+    return false
+  }
+
+  async getCount(contractTxId, min = 5) {
+    if (
+      isNil(this.redisEnabled) ||
+      !this.redisEnabled ||
+      !this.redisClient ||
+      contractTxId == ""
+    ) {
+      console.log(`contractTxId ERROR: ${contractTxId}`)
+      return false
+    }
+    const loopcnt = Math.ceil(min / this.every)
+    // console.log(`min: ${min}`)
+    // console.log(`this.every: ${this.every}`)
+    if (loopcnt <= 0 || !loopcnt || loopcnt == NaN) {
+      loopcnt = 1
+    }
+    let total = 0
+    let t = Date.now()
+    // console.log(`loopcnt: ${loopcnt}`)
+    for (let i = 0; i < loopcnt; i++) {
+      const k = this._getKey(contractTxId, t)
+      // console.log(`k: ${k}, contractTxId: ${contractTxId}`)
+      if (k && typeof k == "string") {
+        const _cnt = await this.redisClient.get(k)
+        if (_cnt) {
+          const cnt = parseInt(_cnt, 10)
+          if (cnt && cnt >= 0) {
+            total = total + cnt
+          }
+        } else {
+          console.log(`k=${k}, _cnt={$_cnt}`)
+        }
+      } else {
+      }
+      t = t - this.every * 1000 * 60
+    }
+    return total
+  }
+}
+
+module.exports = RateLimitCounter

--- a/grpc-node/node-server/sample.weavedb.config.js
+++ b/grpc-node/node-server/sample.weavedb.config.js
@@ -13,6 +13,10 @@ module.exports = {
   //   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   //   region: process.env.AWS_REGION,
   // },
+  // ratelimit: {
+  //   every: 5,
+  //   limit: 300
+  // },
   cache: "lmdb", // or "leveldb"
   // redis: {
   //   url: `redis://${process.env.REDISPORT}:${process.env.REDISPORT}`,


### PR DESCRIPTION
You can set access restrictions for all each contracts  in specific period. 

To use this setting, specify `ratelimit` option in `weavedb.config.js`. 

You need to setup redis setting as well. 

The below setting enables you to limit 300 accesses in 5 min. 

```js
module.exports = {
  ratelimit: {
    every: 5,
    limit: 300
  },
   redis: {
    url: "redis://localhost:6379"
  },
}
```
