### PR TITLE
add .dockerignore for build node-server image after local development on non-linux environment. 

### DIFF
--- a/grpc-node/node-server/.dockerignore
+++ b/grpc-node/node-server/.dockerignore
@@ -1,0 +1,5 @@
+
+
+node_modules
+
+


### PR DESCRIPTION
For this issues 
https://github.com/weavedb/weavedb/issues/381