### PR TITLE
[tools] rename to dbModule

### DIFF
--- a/tools/workspace/scripts/deploy.js
+++ b/tools/workspace/scripts/deploy.js
@@ -7,7 +7,7 @@ let {
   network,
   owner,
   type,
-  module,
+  dbModule,
   scheduler,
 } = require("yargs")(process.argv.slice(2)).parserConfiguration({
   "parse-numbers": false,
@@ -16,8 +16,8 @@ let {
 if (isNil(type)) type = "warp"
 
 if (type === "ao") {
-  if (isNil(module)) {
-    console.error(`module not specified`)
+  if (isNil(dbModule)) {
+    console.error(`dbModule not specified`)
     process.exit()
   }
   if (isNil(scheduler)) {
@@ -72,7 +72,7 @@ const main = async () => {
         op: "deploy_contract",
         key: name,
         type: "ao",
-        module,
+        module: dbModule,
         scheduler,
       },
       { privateKey, nonce: 1 },


### PR DESCRIPTION
`module` might be a reserved word in nodejs.
I'm getting the error below when running the deploy script.

> SyntaxError: Identifier 'module' has already been declared
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1178:20)
    at Module._compile (node:internal/modules/cjs/loader:1220:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12)
    at node:internal/main/run_main_module:23:47